### PR TITLE
Adjust search path and maxdepth of find command

### DIFF
--- a/gearman-defaults.sh
+++ b/gearman-defaults.sh
@@ -17,5 +17,5 @@ GEARMAN_USER=${GEARMAN_USER:-www-data}
 # For multisites requiring per-site routing, a different router is provided
 # at https://github.com/discoverygarden/gearman-multisite-job-router
 ROUTER=${ROUTER:-"$DRUSH --root=$DRUPAL_ROOT -u 1 islandora-job-router"}
-SITE_URI_LIST=${SITE_URI_LIST:-$(for i in `find -L $DRUPAL_ROOT -name settings.php`; do basename `dirname $i`; done)}
+SITE_URI_LIST=${SITE_URI_LIST:-$(for i in `find -L $DRUPAL_ROOT/sites -maxdepth 2 -name settings.php`; do basename `dirname $i`; done)}
 CUSTOM_WORKER_FUCTIONS=${CUSTOM_WORKER_FUCTIONS:-"-f default"}


### PR DESCRIPTION
By limiting the search to just the sites directory, the find command
returns the desired result in 1s instead of 30+ minutes on nfs mounted
drupal filesystems.